### PR TITLE
Improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,24 +2,23 @@ name: Build and test library
 
 on:
   push:
-    branches: [ develop ]
+    branches: [develop]
   pull_request:
-    branches: [ develop ]
+    branches: [develop]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
+      - uses: actions/checkout@v3.3.0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3.0.3
+        with:
+          dotnet-version: 7.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+      - name: Test
+        run: dotnet test --no-build --verbosity normal

--- a/ConcurrentPriorityQueue/ConcurrentPriorityQueue.csproj
+++ b/ConcurrentPriorityQueue/ConcurrentPriorityQueue.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Authors>Noam Yogev</Authors>
     <Company />
     <Description>A thread-safe generic first in-first out (FIFO) collection with support for priority queuing.
@@ -19,7 +19,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CSharpFunctionalExtensions" Version="1.18.2" />
+    <PackageReference Include="CSharpFunctionalExtensions" Version="2.37.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/ConcurrentPriorityQueue/ConcurrentPriorityQueue.csproj
+++ b/ConcurrentPriorityQueue/ConcurrentPriorityQueue.csproj
@@ -22,15 +22,4 @@
     <PackageReference Include="CSharpFunctionalExtensions" Version="2.37.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/ConcurrentPriorityQueue/Core/ConcurrentPriorityQueue.cs
+++ b/ConcurrentPriorityQueue/Core/ConcurrentPriorityQueue.cs
@@ -33,7 +33,7 @@ namespace ConcurrentPriorityQueue.Core
         {
             lock (SyncRoot)
             {
-                return _internalQueues.OrderBy((q) => q.Key).Select((q) => q.Value).SelectMany((q) => q).ToArray();
+                return _internalQueues.OrderBy((q) => q.Key).SelectMany((q) => q.Value).ToArray();
             }
         }
 

--- a/ConcurrentPriorityQueue/Core/ConcurrentPriorityQueue.cs
+++ b/ConcurrentPriorityQueue/Core/ConcurrentPriorityQueue.cs
@@ -26,12 +26,7 @@ namespace ConcurrentPriorityQueue.Core
 
         public object SyncRoot { get; } = new object();
 
-        public void CopyTo(T[] array, int index)
-        {
-            var itemsArray = ToArray();
-            lock (SyncRoot)
-                itemsArray.CopyTo(array, index);
-        }
+        public void CopyTo(T[] array, int index) => ToArray().CopyTo(array, index);
 
         public void CopyTo(Array array, int index) => CopyTo((T[])array, index);
 
@@ -39,13 +34,7 @@ namespace ConcurrentPriorityQueue.Core
         {
             lock (SyncRoot)
             {
-                var itemsList = new List<T>();
-                foreach (var queue in _internalQueues.OrderBy(q => q.Key).Select(q => q.Value))
-                {
-                    itemsList.AddRange(queue.ToArray());
-                }
-
-                return itemsList.ToArray();
+                return _internalQueues.OrderBy((q) => q.Key).Select((q) => q.Value).SelectMany((q) => q).ToArray();
             }
         }
 
@@ -54,12 +43,14 @@ namespace ConcurrentPriorityQueue.Core
         public bool TryTake(out T item)
         {
             var result = Dequeue();
-            lock (SyncRoot)
+
+            if (result.IsFailure)
             {
                 item = default;
-                if (result.IsFailure)
-                    return false;
-
+                return false;
+            }
+            else
+            {
                 item = result.Value;
                 return true;
             }
@@ -71,7 +62,10 @@ namespace ConcurrentPriorityQueue.Core
 
         public Result Enqueue(T item)
         {
-            lock (SyncRoot) return AddOrUpdate(item);
+            lock (SyncRoot)
+            {
+                return AddOrUpdate(item);
+            }
         }
 
         public Result<T> Dequeue()
@@ -79,8 +73,8 @@ namespace ConcurrentPriorityQueue.Core
             lock (SyncRoot)
             {
                 return GetNextQueue()
-                    .OnSuccess(q => q.Dequeue())
-                    .OnFailure(err => Result.Fail(err));
+                    .Map(q => q.Dequeue())
+                    .TapError(err => Result.Failure(err));
             }
         }
 
@@ -89,37 +83,36 @@ namespace ConcurrentPriorityQueue.Core
             lock (SyncRoot)
             {
                 return GetNextQueue()
-                    .OnSuccess(q => q.Peek())
-                    .OnFailure(err => Result.Fail(err));
+                    .Map(q => q.Peek())
+                    .TapError(err => Result.Failure(err));
             }
         }
 
         private Result<Queue<T>> GetNextQueue()
         {
-            foreach (var queue in _internalQueues.OrderBy(q => q.Key).Select(q => q.Value))
-            {
-                try
-                {
-                    queue.Peek();
-                    return Result.Ok(queue);
-                }
-                catch (Exception) { }
-            }
-
-            return Result.Fail<Queue<T>>("Could not find a queue with items.");
+            return _internalQueues.OrderBy((q) => q.Key).Select((q) => q.Value).FirstOrDefault((q) => q.Count > 0) is Queue<T> queue
+                ? Result.Success(queue)
+                : Result.Failure<Queue<T>>("Could not find a queue with items.");
         }
 
         private Result AddOrUpdate(T item)
         {
-            if (!_internalQueues.ContainsKey(item.Priority))
+            if (_internalQueues.TryGetValue(item.Priority, out Queue<T> queue))
             {
-                if (IsAtMaxCapacity())
-                    return Result.Fail("Reached max capacity.");
-                _internalQueues.Add(item.Priority, new Queue<T>());
+                queue.Enqueue(item);
+                return Result.Success();
             }
-
-            _internalQueues[item.Priority].Enqueue(item);
-            return Result.Ok();
+            else if (!IsAtMaxCapacity())
+            {
+                Queue<T> newQueue = new Queue<T>();
+                newQueue.Enqueue(item);
+                _internalQueues.Add(item.Priority, newQueue);
+                return Result.Success();
+            }
+            else
+            {
+                return Result.Failure("Reached max capacity.");
+            }
         }
 
         private bool IsAtMaxCapacity() => _capacity != 0 && Count == _capacity;

--- a/ConcurrentPriorityQueue/Core/ConcurrentPriorityQueue.cs
+++ b/ConcurrentPriorityQueue/Core/ConcurrentPriorityQueue.cs
@@ -19,8 +19,7 @@ namespace ConcurrentPriorityQueue.Core
             _capacity = capacity;
         }
 
-        public int Count => _internalQueues.Count == 0 ? _internalQueues.Count :
-            _internalQueues.Values.Select(q => q.Count).Aggregate((a, b) => a + b);
+        public int Count => _internalQueues.Values.Sum((q) => q.Count);
 
         public bool IsSynchronized => true;
 

--- a/ConcurrentPriorityQueueTests/ConcurrentPriorityQueueTests.csproj
+++ b/ConcurrentPriorityQueueTests/ConcurrentPriorityQueueTests.csproj
@@ -29,15 +29,4 @@
     <ProjectReference Include="..\ConcurrentPriorityQueue\ConcurrentPriorityQueue.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/ConcurrentPriorityQueueTests/ConcurrentPriorityQueueTests.csproj
+++ b/ConcurrentPriorityQueueTests/ConcurrentPriorityQueueTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <CodeAnalysisRuleSet>..\ConcurrentPriorityQueue.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -15,15 +15,29 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.analyzers" Version="1.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ConcurrentPriorityQueue\ConcurrentPriorityQueue.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/ConcurrentPriorityQueueTests/PriorityQueueBlockingCollectionUnitTests.cs
+++ b/ConcurrentPriorityQueueTests/PriorityQueueBlockingCollectionUnitTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using ConcurrentPriorityQueue;
 using ConcurrentPriorityQueue.Core;
@@ -33,7 +32,7 @@ namespace ConcurrentPriorityQueueTests
                 .ContinueWith(t => _targetCollection.CompleteAdding());
 
             // Take items as long as they continue to be added.
-            _ = Task.Run(() => TakeItems()).ConfigureAwait(false);
+            _ = Task.Run(TakeItems).ConfigureAwait(false);
 
             // Wait for all tasks to end.
             await Task.WhenAll(AddItems(numberOfItemsToAdd, defaultSleepTimeBetweenAdds), TakeItems()).ConfigureAwait(false);

--- a/ConcurrentPriorityQueueTests/PriorityQueueUnitTests.cs
+++ b/ConcurrentPriorityQueueTests/PriorityQueueUnitTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace ConcurrentPriorityQueueTests
 {
     /// <summary>
-    /// Test general functionalty of the queue [Enqueue, Dequeue, Peek]
+    /// Test general functionalty of the queue [Enqueue, Dequeue, Peek].
     /// </summary>
     public class PriorityQueueUnitTests
     {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,11 +3,11 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.63">
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/GenericConcurrentPriorityQueueTests/GenericConcurrentPriorityQueueTests.csproj
+++ b/GenericConcurrentPriorityQueueTests/GenericConcurrentPriorityQueueTests.csproj
@@ -1,20 +1,34 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.analyzers" Version="1.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ConcurrentPriorityQueue\ConcurrentPriorityQueue.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/GenericConcurrentPriorityQueueTests/GenericConcurrentPriorityQueueTests.csproj
+++ b/GenericConcurrentPriorityQueueTests/GenericConcurrentPriorityQueueTests.csproj
@@ -20,15 +20,4 @@
     <ProjectReference Include="..\ConcurrentPriorityQueue\ConcurrentPriorityQueue.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/GenericConcurrentPriorityQueueTests/GenericPriorityQueueUnitTests.cs
+++ b/GenericConcurrentPriorityQueueTests/GenericPriorityQueueUnitTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace GenericConcurrentPriorityQueueTests
 {
     /// <summary>
-    /// Test general functionalty of the queue [Enqueue, Dequeue, Peek]
+    /// Test general functionalty of the queue [Enqueue, Dequeue, Peek].
     /// </summary>
     public class GenericPriorityQueueUnitTests
     {

--- a/GenericConcurrentPriorityQueueTests/TimeToProcess.cs
+++ b/GenericConcurrentPriorityQueueTests/TimeToProcess.cs
@@ -18,5 +18,7 @@ namespace GenericConcurrentPriorityQueueTests
             TimeInMilliseconds.Equals(other.TimeInMilliseconds);
 
         public override int GetHashCode() => TimeInMilliseconds.GetHashCode();
+
+        public override bool Equals(object obj) => obj is TimeToProcess process && Equals(process);
     }
 }


### PR DESCRIPTION
1. Removed unnecessary lock in some functions
2. Upgrade to latest dependency
3. Upgrade to .Net 7.0
4. Optimize the GetNextQueue and AddOrUpdate to make it faster
5. Clean up the code to fix .Net Analyzers's error
6. Add Equals overrides on TimeToProcess class to fix the failure on GenericPriorityQueueUnitTests