### PR TITLE
Multiple target frameworks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,14 +8,17 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v3.3.0
       - name: Setup .NET
         uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: 7.x
+          dotnet-version: |
+            7.x
+            6.x
+            2.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/ConcurrentPriorityQueue/ConcurrentPriorityQueue.csproj
+++ b/ConcurrentPriorityQueue/ConcurrentPriorityQueue.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net48;netstandard2.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
-    <Authors>Noam Yogev</Authors>
+	<TargetFrameworks>net48;netstandard2.0;net6.0;net7.0</TargetFrameworks>
+	<Authors>Noam Yogev</Authors>
     <Company />
     <Description>A thread-safe generic first in-first out (FIFO) collection with support for priority queuing.
 </Description>
@@ -20,6 +20,13 @@
 
   <ItemGroup>
     <PackageReference Include="CSharpFunctionalExtensions" Version="2.37.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.33">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/ConcurrentPriorityQueue/ConcurrentPriorityQueue.csproj
+++ b/ConcurrentPriorityQueue/ConcurrentPriorityQueue.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net461;net48;netstandard2.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <Authors>Noam Yogev</Authors>
     <Company />
     <Description>A thread-safe generic first in-first out (FIFO) collection with support for priority queuing.

--- a/ConcurrentPriorityQueue/Core/IHavePriority.cs
+++ b/ConcurrentPriorityQueue/Core/IHavePriority.cs
@@ -5,6 +5,6 @@ namespace ConcurrentPriorityQueue.Core
     public interface IHavePriority<TP>
         where TP : IEquatable<TP>, IComparable<TP>
     {
-        TP Priority { get; set; }
+        TP Priority { get; }
     }
 }

--- a/ConcurrentPriorityQueueTests/ConcurrentPriorityQueueTests.csproj
+++ b/ConcurrentPriorityQueueTests/ConcurrentPriorityQueueTests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net461;net48;netstandard2.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
-	<CodeAnalysisRuleSet>..\ConcurrentPriorityQueue.ruleset</CodeAnalysisRuleSet>
+	<TargetFrameworks>net48;netcoreapp2.0;net6.0;net7.0</TargetFrameworks>
+    <CodeAnalysisRuleSet>..\ConcurrentPriorityQueue.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -15,18 +15,31 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.analyzers" Version="1.1.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+	<PackageReference Include="FluentAssertions" Version="6.9.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" Condition="'$(TargetFramework)' != 'netcoreapp2.0'" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
+	<PackageReference Include="xunit" Version="2.4.1" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
+	<PackageReference Include="xunit" Version="2.4.2" Condition="'$(TargetFramework)' != 'netcoreapp2.0'" />
+	<PackageReference Include="xunit.analyzers" Version="1.1.0" />
+	<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+	  <PrivateAssets>all</PrivateAssets>
+	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	</PackageReference>
+	<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
+	  <PrivateAssets>all</PrivateAssets>
+	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	</PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ConcurrentPriorityQueue\ConcurrentPriorityQueue.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.33">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/ConcurrentPriorityQueueTests/ConcurrentPriorityQueueTests.csproj
+++ b/ConcurrentPriorityQueueTests/ConcurrentPriorityQueueTests.csproj
@@ -4,6 +4,7 @@
 	<TargetFrameworks>net48;netcoreapp2.0;net6.0;net7.0</TargetFrameworks>
     <CodeAnalysisRuleSet>..\ConcurrentPriorityQueue.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
+	<IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/ConcurrentPriorityQueueTests/ConcurrentPriorityQueueTests.csproj
+++ b/ConcurrentPriorityQueueTests/ConcurrentPriorityQueueTests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <CodeAnalysisRuleSet>..\ConcurrentPriorityQueue.ruleset</CodeAnalysisRuleSet>
+	<TargetFrameworks>net461;net48;netstandard2.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+	<CodeAnalysisRuleSet>..\ConcurrentPriorityQueue.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/GenericConcurrentPriorityQueueTests/GenericConcurrentPriorityQueueTests.csproj
+++ b/GenericConcurrentPriorityQueueTests/GenericConcurrentPriorityQueueTests.csproj
@@ -1,23 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net461;net48;netstandard2.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+	<TargetFrameworks>net48;netcoreapp2.0;net6.0;net7.0</TargetFrameworks>
 	<IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" Condition="'$(TargetFramework)' != 'netcoreapp2.0'" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
+	<PackageReference Include="xunit" Version="2.4.1" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
+	<PackageReference Include="xunit" Version="2.4.2" Condition="'$(TargetFramework)' != 'netcoreapp2.0'" />
     <PackageReference Include="xunit.analyzers" Version="1.1.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+	<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
+	  <PrivateAssets>all</PrivateAssets>
+	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	</PackageReference>
   </ItemGroup>
-
+	
   <ItemGroup>
     <ProjectReference Include="..\ConcurrentPriorityQueue\ConcurrentPriorityQueue.csproj" />
+  </ItemGroup>
+	
+  <ItemGroup>
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.33">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/GenericConcurrentPriorityQueueTests/GenericConcurrentPriorityQueueTests.csproj
+++ b/GenericConcurrentPriorityQueueTests/GenericConcurrentPriorityQueueTests.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <IsPackable>false</IsPackable>
+	<TargetFrameworks>net461;net48;netstandard2.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+	<IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GenericConcurrentPriorityQueueTests/GenericConcurrentPriorityQueueTests.csproj
+++ b/GenericConcurrentPriorityQueueTests/GenericConcurrentPriorityQueueTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
 	<TargetFrameworks>net48;netcoreapp2.0;net6.0;net7.0</TargetFrameworks>
 	<IsPackable>false</IsPackable>
+	<IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-
-
 # ConcurrentPriorityQueue ![Build Workflow](https://github.com/noamyogev84/ConcurrentPriorityQueue/actions/workflows/build.yml/badge.svg) ![Nuget](https://img.shields.io/nuget/v/ConcurrentPriorityQueue)
+
 A thread-safe generic first in first out (FIFO) collection with support for priority queuing.
 
 Nuget: [https://www.nuget.org/packages/ConcurrentPriorityQueue](https://www.nuget.org/packages/ConcurrentPriorityQueue)
@@ -8,13 +7,14 @@ Nuget: [https://www.nuget.org/packages/ConcurrentPriorityQueue](https://www.nuge
 ### Features
 
 1. Thread-Safe.
-2. Manages items  according to a `First in first out` policy and `priority` on top of that.
+2. Manages items according to a `First in first out` policy and `priority` on top of that.
 3. Implements `IProducerConsumerCollection<T>` interface.
 4. Extends to a `BlockingCollection<T>`.
+5. Supports multi-frameworks, includes `net48` `netstandard2.0` `net6.0` `net7.0`
 
 ### Examples:
 
-  Items in the collection **must** implement the generic interface `IHavePriority<T>` where T: implements `IEquatable<T>`, `IComparable<T>` and also overrides `Object.GetHashCode()`:
+Items in the collection **must** implement the generic interface `IHavePriority<T>` where T: implements `IEquatable<T>`, `IComparable<T>` and also overrides `Object.GetHashCode()`:
 
 ```csharp
 // Simplest implementation of IHavePriority<T>
@@ -24,6 +24,7 @@ public class SomeClass : IHavePriority<int> {
 ```
 
 Simple flow for creating a `Priority-By-Integer` queue and adding an item:
+
 ```csharp
 // Create a new prioritized item.
 var itemWithPriority = new SomeClass { Priority = 0 };
@@ -76,13 +77,13 @@ foreach(var item in priorityQueue) {
 }
 ```
 
-`ConcurrentPriorityQueue` supports **Generic Priorities**. 
+`ConcurrentPriorityQueue` supports **Generic Priorities**.
 
 Implement your own **Business Priority** object and configure the queue to handle it:
 
 ```csharp
 // TimeToProcess class implements IEquatable<T>, IComparable<T> and overrides Object.GetHashCode().
-public class TimeToProcess : IEquatable<TimeToProcess>, IComparable<TimeToProcess> {		
+public class TimeToProcess : IEquatable<TimeToProcess>, IComparable<TimeToProcess> {
     public decimal TimeInMilliseconds { get; set;}
 
     public int CompareTo(TimeToProcess other) =>
@@ -139,8 +140,7 @@ foreach(var item in blockingPriorityQueue.GetConsumingEnumerable()) {
 ```
 
 ### Additional information and resources:
- - [IProducerConsumerCollection<T> Documentation](https://docs.microsoft.com/en-us/dotnet/api/system.collections.concurrent.iproducerconsumercollection-1?view=netframework-4.8)
- - [BlockingCollection<T> Documentation](https://docs.microsoft.com/en-us/dotnet/api/system.collections.concurrent.blockingcollection-1?view=netframework-4.8)
- - [Functional Extensions for C#](https://github.com/vkhorikov/CSharpFunctionalExtensions)
 
-
+- [IProducerConsumerCollection<T> Documentation](https://docs.microsoft.com/en-us/dotnet/api/system.collections.concurrent.iproducerconsumercollection-1?view=netframework-4.8)
+- [BlockingCollection<T> Documentation](https://docs.microsoft.com/en-us/dotnet/api/system.collections.concurrent.blockingcollection-1?view=netframework-4.8)
+- [Functional Extensions for C#](https://github.com/vkhorikov/CSharpFunctionalExtensions)


### PR DESCRIPTION
Previously, only .Net 7.0 is supported only, and most C# repo might not be able to use that.
This PR add support for multiple target framework: `net48` `netstandard2.0` `net6.0` `net7.0`