### PR TITLE
Use .Net 8.0 instead of .Net 7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,20 +8,27 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3.3.0
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
+
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3.0.3
+        uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: |
-            7.x
+            8.x
             6.x
             2.x
+
       - name: Restore dependencies
         run: dotnet restore
+
       - name: Build
         run: dotnet build --no-restore
+
       - name: Test
         run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,14 @@
-name: Build and test library
+name: Build and Test ConcurrentPriorityQueue
 
 on:
   push:
     branches: [develop]
   pull_request:
     branches: [develop]
+
+concurrency:
+  group: ${{github.workflow}}-${{github.event.pull_request.number || github.ref}}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.globalconfig
+++ b/.globalconfig
@@ -24,9 +24,6 @@ dotnet_diagnostic.SA1309.severity = none
 # SA1101: Prefix local calls with this
 dotnet_diagnostic.SA1101.severity = none
 
-# Default severity for all analyzer diagnostics
-dotnet_analyzer_diagnostic.severity = error
-
 # IDE0011: Add braces
 csharp_prefer_braces = when_multiline
 

--- a/ConcurrentPriorityQueue.sln
+++ b/ConcurrentPriorityQueue.sln
@@ -1,18 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30523.141
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34408.163
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConcurrentPriorityQueue", "ConcurrentPriorityQueue\ConcurrentPriorityQueue.csproj", "{E6C7464F-9840-4477-AB3E-8D7A4539D016}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConcurrentPriorityQueueTests", "ConcurrentPriorityQueueTests\ConcurrentPriorityQueueTests.csproj", "{E457395E-76DD-45D4-A898-C6D299ACF7AD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GenericConcurrentPriorityQueueTests", "GenericConcurrentPriorityQueueTests\GenericConcurrentPriorityQueueTests.csproj", "{D5BAFA8A-1330-468A-B183-451C5349F198}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DD33233E-9CC4-4DEE-BEE7-AAADEC1EDB65}"
-	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/ConcurrentPriorityQueue/ConcurrentPriorityQueue.csproj
+++ b/ConcurrentPriorityQueue/ConcurrentPriorityQueue.csproj
@@ -1,32 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net48;netstandard2.0;net6.0;net7.0</TargetFrameworks>
+	<IsTrimmable>true</IsTrimmable>
+	<TargetFrameworks>net48;netstandard2.0;net6.0;net8.0</TargetFrameworks>
 	<Authors>Noam Yogev</Authors>
-    <Company />
-    <Description>A thread-safe generic first in-first out (FIFO) collection with support for priority queuing.
-</Description>
+    <Description>A thread-safe generic first in-first out (FIFO) collection with support for priority queuing.</Description>
     <PackageProjectUrl>https://github.com/noamyogev84/ConcurrentPriorityQueue</PackageProjectUrl>
     <RepositoryUrl>https://github.com/noamyogev84/ConcurrentPriorityQueue</RepositoryUrl>
     <PackageTags>threading thread-safe producerconsumer concurrent-collection concurrent blocking-collection collections</PackageTags>
     <PackageId>PriorityConcurrentQueue</PackageId>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-  </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="CSharpFunctionalExtensions" Version="2.37.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.33">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+	  <PackageReference Include="CSharpFunctionalExtensions" Version="2.40.3" />
   </ItemGroup>
 
 </Project>

--- a/ConcurrentPriorityQueueTests/ConcurrentPriorityQueueTests.csproj
+++ b/ConcurrentPriorityQueueTests/ConcurrentPriorityQueueTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net48;netcoreapp2.0;net6.0;net7.0</TargetFrameworks>
+	<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
     <CodeAnalysisRuleSet>..\ConcurrentPriorityQueue.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
 	<IsTestProject>true</IsTestProject>
@@ -16,17 +16,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="FluentAssertions" Version="6.9.0" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" Condition="'$(TargetFramework)' != 'netcoreapp2.0'" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
+	<PackageReference Include="FluentAssertions" Version="6.12.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 	<PackageReference Include="xunit" Version="2.4.1" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
-	<PackageReference Include="xunit" Version="2.4.2" Condition="'$(TargetFramework)' != 'netcoreapp2.0'" />
-	<PackageReference Include="xunit.analyzers" Version="1.1.0" />
-	<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-	  <PrivateAssets>all</PrivateAssets>
-	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	</PackageReference>
-	<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
+	<PackageReference Include="xunit" Version="2.6.5" Condition="'$(TargetFramework)' != 'netcoreapp2.0'" />
+	<PackageReference Include="xunit.analyzers" Version="1.9.0" />
+	<PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
@@ -34,13 +29,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ConcurrentPriorityQueue\ConcurrentPriorityQueue.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.33">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/ConcurrentPriorityQueueTests/PriorityQueueBlockingCollectionUnitTests.cs
+++ b/ConcurrentPriorityQueueTests/PriorityQueueBlockingCollectionUnitTests.cs
@@ -22,25 +22,25 @@ namespace ConcurrentPriorityQueueTests
         }
 
         [Fact]
-        public async Task Test_ConsumingTaskBlocksUntilNoMoreAdditions()
+        public async Task Test_ConsumingTaskBlocksUntilNoMoreAdditionsAsync()
         {
             const int numberOfItemsToAdd = 10;
             const int defaultSleepTimeBetweenAdds = 1000;
 
             // Add items and signal for completion when done.
-            _ = Task.Run(() => AddItems(numberOfItemsToAdd, defaultSleepTimeBetweenAdds))
+            _ = Task.Run(() => AddItemsAsync(numberOfItemsToAdd, defaultSleepTimeBetweenAdds))
                 .ContinueWith(t => _targetCollection.CompleteAdding());
 
             // Take items as long as they continue to be added.
-            _ = Task.Run(TakeItems).ConfigureAwait(false);
+            _ = Task.Run(TakeItemsAsync).ConfigureAwait(true);
 
             // Wait for all tasks to end.
-            await Task.WhenAll(AddItems(numberOfItemsToAdd, defaultSleepTimeBetweenAdds), TakeItems()).ConfigureAwait(false);
+            await Task.WhenAll(AddItemsAsync(numberOfItemsToAdd, defaultSleepTimeBetweenAdds), TakeItemsAsync()).ConfigureAwait(true);
         }
 
         public void Dispose() => _targetCollection.Dispose();
 
-        private async Task AddItems(int numberOfItemsToAdd, int sleepTime = 0)
+        private async Task AddItemsAsync(int numberOfItemsToAdd, int sleepTime = 0)
         {
             for (var i = 0; i < numberOfItemsToAdd; ++i)
             {
@@ -49,7 +49,7 @@ namespace ConcurrentPriorityQueueTests
             }
         }
 
-        private Task TakeItems()
+        private Task TakeItemsAsync()
         {
             // blocks until signaled on completion.
             foreach (var item in _targetCollection.GetConsumingEnumerable())

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,19 +1,16 @@
 <Project>
-    <PropertyGroup>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27">
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.8.14">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
       </ItemGroup>
 </Project>

--- a/GenericConcurrentPriorityQueueTests/GenericConcurrentPriorityQueueTests.csproj
+++ b/GenericConcurrentPriorityQueueTests/GenericConcurrentPriorityQueueTests.csproj
@@ -1,23 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net48;netcoreapp2.0;net6.0;net7.0</TargetFrameworks>
+	<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
 	<IsPackable>false</IsPackable>
 	<IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" Condition="'$(TargetFramework)' != 'netcoreapp2.0'" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
-	<PackageReference Include="xunit" Version="2.4.1" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
-	<PackageReference Include="xunit" Version="2.4.2" Condition="'$(TargetFramework)' != 'netcoreapp2.0'" />
-    <PackageReference Include="xunit.analyzers" Version="1.1.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-	<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+	<PackageReference Include="xunit" Version="2.6.5" />
+    <PackageReference Include="xunit.analyzers" Version="1.9.0" />
+	<PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
@@ -27,11 +21,4 @@
     <ProjectReference Include="..\ConcurrentPriorityQueue\ConcurrentPriorityQueue.csproj" />
   </ItemGroup>
 	
-  <ItemGroup>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.33">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
1. Update some third-party components
2. Remove netcoreapp2.0 from test project due to security vulnerability
3. Mark library as Trimmable
4. Support .Net 8.0 and drop support for .Net 7.0